### PR TITLE
Fix lookup error returning literal string instead of the appropiate one from the locales

### DIFF
--- a/src/Production/Commands/general/lookup.js
+++ b/src/Production/Commands/general/lookup.js
@@ -14,7 +14,7 @@ class Lookup extends Command {
 
   async run(ctx) {
     const lookup = ctx.args.join(' ');
-    if (!lookup) return ctx.channel.send(ctx.__('lookup.noLookup', {
+    if (!lookup) return ctx.channel.send(ctx.__('lookup.error.noLookup', {
       errorIcon: this.client.constants.statusEmotes.error,
     }));
 


### PR DESCRIPTION
~~You easily could have done this yourself but I have nothing better to do currently~~